### PR TITLE
Add service category pages and links

### DIFF
--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import Button from '@/components/ui/Button.vue'
+import { RouterLink } from 'vue-router'
 </script>
 
 <template>
@@ -43,24 +44,33 @@ import Button from '@/components/ui/Button.vue'
     <h2 class="text-2xl font-bold text-center mb-10">Почему выбирают нас</h2>
 
     <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
-      <div class="p-6 bg-white rounded-xl shadow-sm border text-center">
+      <RouterLink
+        to="/services/apple"
+        class="p-6 bg-white rounded-xl shadow-sm border text-center block"
+      >
         <h3 class="font-semibold mb-2">Экосистема Apple</h3>
         <p class="text-sm text-slate-600">
           10+ лет опыта настройки устройств, MDM-решений и обучения сотрудников.
         </p>
-      </div>
-      <div class="p-6 bg-white rounded-xl shadow-sm border text-center">
+      </RouterLink>
+      <RouterLink
+        to="/services/ai"
+        class="p-6 bg-white rounded-xl shadow-sm border text-center block"
+      >
         <h3 class="font-semibold mb-2">Нейросети &amp; AI-агенты</h3>
         <p class="text-sm text-slate-600">
           Внедряем ChatGPT-решения, создаём кастомных агентов на базе LLM.
         </p>
-      </div>
-      <div class="p-6 bg-white rounded-xl shadow-sm border text-center">
+      </RouterLink>
+      <RouterLink
+        to="/services/audit"
+        class="p-6 bg-white rounded-xl shadow-sm border text-center block"
+      >
         <h3 class="font-semibold mb-2">Бизнес-аудит</h3>
         <p class="text-sm text-slate-600">
           Анализ текущих IT-процессов и подбор оптимальных инструментов.
         </p>
-      </div>
+      </RouterLink>
     </div>
   </section>
 </template>

--- a/src/pages/ServiceAI.vue
+++ b/src/pages/ServiceAI.vue
@@ -1,0 +1,13 @@
+<script setup>
+</script>
+
+<template>
+  <section class="container mx-auto px-4 py-8">
+    <h1 class="text-2xl font-bold mb-6">Нейросети &amp; AI-агенты</h1>
+    <p>Здесь будут услуги по внедрению нейросетей и созданию AI-агентов.</p>
+  </section>
+</template>
+
+<style scoped>
+.container { max-width: 960px; }
+</style>

--- a/src/pages/ServiceApple.vue
+++ b/src/pages/ServiceApple.vue
@@ -1,0 +1,13 @@
+<script setup>
+</script>
+
+<template>
+  <section class="container mx-auto px-4 py-8">
+    <h1 class="text-2xl font-bold mb-6">Экосистема Apple</h1>
+    <p>Здесь будут услуги, связанные с техникой Apple.</p>
+  </section>
+</template>
+
+<style scoped>
+.container { max-width: 960px; }
+</style>

--- a/src/pages/ServiceAudit.vue
+++ b/src/pages/ServiceAudit.vue
@@ -1,0 +1,13 @@
+<script setup>
+</script>
+
+<template>
+  <section class="container mx-auto px-4 py-8">
+    <h1 class="text-2xl font-bold mb-6">Бизнес-аудит</h1>
+    <p>Анализ IT-процессов и подбор оптимальных инструментов.</p>
+  </section>
+</template>
+
+<style scoped>
+.container { max-width: 960px; }
+</style>

--- a/src/pages/Services.vue
+++ b/src/pages/Services.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted } from 'vue'
+import { RouterLink } from 'vue-router'
 import axios from 'axios'
 
 const loading = ref(true)
@@ -18,6 +19,36 @@ onMounted(async () => {
 <template>
   <section class="container mx-auto px-4 py-8">
     <h1 class="text-2xl font-bold mb-6">Услуги</h1>
+
+    <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3 mb-8">
+      <RouterLink
+        to="/services/apple"
+        class="p-6 bg-white rounded-xl shadow-sm border text-center block"
+      >
+        <h3 class="font-semibold mb-2">Экосистема Apple</h3>
+        <p class="text-sm text-slate-600">
+          10+ лет опыта настройки устройств, MDM-решений и обучения сотрудников.
+        </p>
+      </RouterLink>
+      <RouterLink
+        to="/services/ai"
+        class="p-6 bg-white rounded-xl shadow-sm border text-center block"
+      >
+        <h3 class="font-semibold mb-2">Нейросети &amp; AI-агенты</h3>
+        <p class="text-sm text-slate-600">
+          Внедряем ChatGPT-решения, создаём кастомных агентов на базе LLM.
+        </p>
+      </RouterLink>
+      <RouterLink
+        to="/services/audit"
+        class="p-6 bg-white rounded-xl shadow-sm border text-center block"
+      >
+        <h3 class="font-semibold mb-2">Бизнес-аудит</h3>
+        <p class="text-sm text-slate-600">
+          Анализ текущих IT-процессов и подбор оптимальных инструментов.
+        </p>
+      </RouterLink>
+    </div>
 
     <p v-if="loading">Загрузка…</p>
     <p v-else-if="!services.length" class="text-gray-500">Услуг пока нет</p>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,6 +4,9 @@ import Catalog from '../pages/Catalog.vue'
 import About from '../pages/About.vue'
 import Services from '../pages/Services.vue'
 import Projects from '../pages/Projects.vue'
+import ServiceApple from '../pages/ServiceApple.vue'
+import ServiceAI from '../pages/ServiceAI.vue'
+import ServiceAudit from '../pages/ServiceAudit.vue'
 
 
 
@@ -15,6 +18,9 @@ export default createRouter({
     { path: '/catalog', component: Catalog },
     { path: '/about', component: About },
     { path: '/services', component: Services },
+    { path: '/services/apple', component: ServiceApple },
+    { path: '/services/ai', component: ServiceAI },
+    { path: '/services/audit', component: ServiceAudit },
     { path: '/projects', component: Projects }
   ],
 })


### PR DESCRIPTION
## Summary
- link service cards on home page to new dedicated pages
- add grid of service cards on Services page
- add pages for Apple, AI, and Audit services
- register new routes

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849e6246874833294921725ae6c34d0