### PR TITLE
Add contact links on about page

### DIFF
--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -22,10 +22,24 @@ onMounted(async () => {
     <p v-if="loading">Загрузка…</p>
     <p v-else-if="!about" class="text-gray-500">Данные не получены</p>
 
-    <article v-else class="prose max-w-none">
+    <article v-else class="prose max-w-none mb-8">
       <h2 class="text-xl font-semibold mb-2">{{ about.title }}</h2>
       <div v-html="about.content" />
     </article>
+
+    <div class="bg-white rounded-xl shadow-sm border p-6">
+      <h2 class="text-xl font-semibold mb-4">Свяжитесь с нами</h2>
+      <ul class="space-y-2">
+        <li>
+          Телефон:
+          <a href="tel:" class="text-blue-600 hover:underline">+7 (000) 000‑00‑00</a>
+        </li>
+        <li>
+          Email:
+          <a href="mailto:info@example.com" class="text-blue-600 hover:underline">info@example.com</a>
+        </li>
+      </ul>
+    </div>
   </section>
 </template>
 


### PR DESCRIPTION
## Summary
- add contact block to `/about` with placeholder phone and email links

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6849eb165f488332bfc3a11647911a98